### PR TITLE
Fixing filter for returning unique pool members with Get-PoolMember

### DIFF
--- a/F5-BIGIP/F5-LTM/Public/Get-PoolMember.ps1
+++ b/F5-BIGIP/F5-LTM/Public/Get-PoolMember.ps1
@@ -49,11 +49,11 @@
                         [Regex]::Match($this.selfLink, '(?<=pool/)[^/]*') -replace '~','/'
                     } -Force -PassThru | Add-Member -Name GetFullName -MemberType ScriptMethod {
                         '{0}{1}' -f $this.GetPoolName(),$this.fullPath
-                    } -Force -PassThru | Add-ObjectDetail -TypeName 'PoshLTM.PoolMember' | Select-Object -Unique
+                    } -Force -PassThru | Add-ObjectDetail -TypeName 'PoshLTM.PoolMember'                     
                 }
             }
             PoolName {
-                Get-Pool -F5Session $F5Session -Name $PoolName -Partition $Partition -Application $Application | Get-PoolMember -F5session $F5Session -Address $Address -Name $Name -Application $Application
+                Get-Pool -F5Session $F5Session -Name $PoolName -Partition $Partition -Application $Application | Get-PoolMember -F5session $F5Session -Address $Address -Name $Name -Application $Application | Sort-object Name | Get-Unique –AsString
             }
         }
     }

--- a/F5-BIGIP/F5-LTM/Public/Remove-PoolMember.ps1
+++ b/F5-BIGIP/F5-LTM/Public/Remove-PoolMember.ps1
@@ -57,7 +57,13 @@
                 }
             }
             PoolName {
-                Get-PoolMember -F5session $F5Session -PoolName $PoolName -Partition $Partition -Address $Address -Name $Name -Application $Application | Remove-PoolMember -F5session $F5Session
+                $PoolMember = Get-PoolMember -F5session $F5Session -PoolName $PoolName -Partition $Partition -Address $Address -Name $Name -Application $Application;
+                If ($PoolMember) { 
+                    $PoolMember | Remove-PoolMember -F5session $F5Session
+                }
+                Else {
+                    Write-Warning "Pool member not found"
+                }
             }
         }
     }


### PR DESCRIPTION
Returning a warning for Remove-PoolMember if no member is gotten for removal.
Returning a unique list of pool members for Get-PoolMembers.
Fixed #4 and #6 